### PR TITLE
Fix a potential ordering issue in the Gradle Plugin

### DIFF
--- a/gradle-plugin/src/main/kotlin/se/ansman/autoplugin/gradle/AutoPluginGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/se/ansman/autoplugin/gradle/AutoPluginGradlePlugin.kt
@@ -39,10 +39,10 @@ public abstract class AutoPluginGradlePlugin : Plugin<Project> {
                         resources.srcDir(target.layout.buildDirectory.dir("generated/ksp/src/main/resources"))
                     }
                 }
+                dependencies.add("implementation", "se.ansman.autoplugin:api:${BuildMetadata.VERSION}")
             }
 
             pluginManager.withPlugin("symbol-processing") {
-                dependencies.add("implementation", "se.ansman.autoplugin:api:${BuildMetadata.VERSION}")
                 dependencies.add("ksp", "se.ansman.autoplugin:compiler-ksp:${BuildMetadata.VERSION}")
             }
         }


### PR DESCRIPTION
Since the `implementation` configuration is created by the Kotlin plugin
the api dependency should be added after the Kotlin plugin.