### PR TITLE
Handle plugins located in the root package

### DIFF
--- a/compiler/src/main/kotlin/se/ansman/autoplugin/compiler/ksp/AutoPluginSymbolProcessor.kt
+++ b/compiler/src/main/kotlin/se/ansman/autoplugin/compiler/ksp/AutoPluginSymbolProcessor.kt
@@ -125,6 +125,8 @@ internal class AutoPluginSymbolProcessor : SymbolProcessor {
     private fun KSClassDeclaration.toClassName(): ClassName {
         require(!isLocal()) { "Local/anonymous classes are not supported!" }
         val pkgName = packageName.asString()
+            .takeUnless { it == "<root>" }
+            ?: ""
         val typesString = qualifiedName!!.asString().removePrefix("$pkgName.")
 
         val simpleNames = typesString

--- a/compiler/src/test/kotlin/se/ansman/autoplugin/compiler/BaseAutoPluginProcessorTest.kt
+++ b/compiler/src/test/kotlin/se/ansman/autoplugin/compiler/BaseAutoPluginProcessorTest.kt
@@ -231,6 +231,26 @@ abstract class BaseAutoPluginProcessorTest {
             .isEqualTo("implementation-class=com.example.SomePlugin")
     }
 
+    @Test
+    fun `plugins in root package`() {
+        val result = compile(
+            """
+                import org.gradle.api.Plugin
+                import org.gradle.api.Project
+                import se.ansman.autoplugin.AutoPlugin
+                
+                @AutoPlugin("some-plugin")
+                abstract class SomePlugin : Plugin<Project> {
+                    override fun apply(target: Project) {}
+                }
+            """
+        )
+
+        assertThat(result.exitCode).isEqualTo(OK)
+        assertThat(result.getResourceAsText("META-INF/gradle-plugins/some-plugin.properties"))
+            .isEqualTo("implementation-class=SomePlugin")
+    }
+
     private fun CompileResult.assertMessage(messages: String) {
         messages.lineSequence().forEach { message -> assertThat(this.messages).contains(message) }
     }


### PR DESCRIPTION
KSClassDeclaration.packageName returns <root> for types located in the root package.